### PR TITLE
Add "Apache Spark" under user guide.

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -145,3 +145,7 @@ body {
   }
 }
 
+.container code {
+    background-color: #F1F4F9;
+    color: black;
+}

--- a/docs/guide/interpreter/spark.md
+++ b/docs/guide/interpreter/spark.md
@@ -31,7 +31,7 @@ Check [data loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb
 
 ## Load dependencies
 
-When your code requires external library, `%spark.dep` helps load additional libraries from maven repository. `spark.dep` interpreter leverages Scala environment. You can write scala expressions to call dependency load APIs.
+When your code requires external library, `%spark.dep` helps load additional libraries from maven repository. `%spark.dep` interpreter leverages Scala environment. You can write scala expressions to call dependency load APIs.
 
 Usages
 

--- a/docs/guide/interpreter/spark.md
+++ b/docs/guide/interpreter/spark.md
@@ -14,7 +14,7 @@ ZEPL currently runs single node Apache Spark 2.1.0 in the containers of each not
 
 To load data from AWS S3, first you need configure access key and secret key.
 
-```
+```scala
 %spark
 sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", "[YOUR_ACCESS_KEY]")
 sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "[YOUR_SECRET_KEY]")
@@ -22,7 +22,7 @@ sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "[YOUR_SECRET_KEY]")
 
 And then your Spark context will able to access data from S3
 
-```
+```scala
 %spark
 val data = sc.textFile("s3n://....")
 ```
@@ -35,7 +35,7 @@ When your code requires external library, `%spark.dep` helps load additional lib
 
 Usages
 
-```
+```scala
 %spark.dep
 z.reset() // clean up previously added artifact and repository
 

--- a/docs/guide/interpreter/spark.md
+++ b/docs/guide/interpreter/spark.md
@@ -1,0 +1,74 @@
+<h1> Apache Spark Interpreter </h1>
+
+[Apache Spark](https://spark.apache.org) is an open source processing engine built around speed, ease of use, and sophisticated analytics. ZEPL provides several interpreters for Apache Spark.
+
+ * `%spark` - Provides a Scala environment
+ * `%spark.pyspark` - Provides a Python environment
+ * `%spark.sql` - Provides SparkSQL environment
+ * `%spark.dep` - Load dependency libraries into Spark environment
+
+A single Spark context is shared among `%spark`, `%spark.pyspark`, `%spark.sql` sessions.
+ZEPL currently runs single node Apache Spark 2.1.0 in the containers of each notebooks.
+
+## Load data from AWS S3
+
+To load data from AWS S3, first you need configure access key and secret key.
+
+```
+%spark
+sc.hadoopConfiguration.set("fs.s3n.awsAccessKeyId", "[YOUR_ACCESS_KEY]")
+sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", "[YOUR_SECRET_KEY]")
+```
+
+And then your Spark context will able to access data from S3
+
+```
+%spark
+val data = sc.textFile("s3n://....")
+```
+
+Check [data loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb24vY2RjMzQ1NTljOTkzNDNhMTk4NGE0ZWUzNjU1NjgxZWQvbm90ZS5qc29u) notebook.
+
+## Load dependencies
+
+When your code requires external library, `%spark.dep` helps load additional libraries from maven repository. `spark.dep` interpreter leverages Scala environment. You can write scala expressions to call dependency load APIs.
+
+Usages
+
+```
+%spark.dep
+z.reset() // clean up previously added artifact and repository
+
+// add maven repository
+z.addRepo("RepoName").url("RepoURL")
+
+// add maven snapshot repository
+z.addRepo("RepoName").url("RepoURL").snapshot()
+
+// add credentials for private maven repository
+z.addRepo("RepoName").url("RepoURL").username("username").password("password")
+
+// add artifact from filesystem
+z.load("/path/to.jar")
+
+// add artifact from maven repository, with no dependency
+z.load("groupId:artifactId:version").excludeAll()
+
+// add artifact recursively
+z.load("groupId:artifactId:version")
+
+// add artifact recursively except comma separated GroupID:ArtifactId list
+z.load("groupId:artifactId:version").exclude("groupId:artifactId,groupId:artifactId, ...")
+
+// exclude with pattern
+z.load("groupId:artifactId:version").exclude(*)
+z.load("groupId:artifactId:version").exclude("groupId:artifactId:*")
+z.load("groupId:artifactId:version").exclude("groupId:*")
+
+// local() skips adding artifact to spark clusters (skipping sc.addJar())
+z.load("groupId:artifactId:version").local()
+```
+
+Note that `%spark.dep` should be the first interpreter run in the notebook before `%spark`, `%spark.pyspark`, `%spark.sql`. Otherwise, `%spark.dep` will print error message and you need to shutdown and start the container for the notebook again.
+
+Check [Dependency loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb24vZjBmYWIwNGMzZTcxNDMwN2FjYzIxM2JkYmU3ZWIyZWEvbm90ZS5qc29u) notebook.

--- a/docs/guide/interpreter/spark.md
+++ b/docs/guide/interpreter/spark.md
@@ -33,6 +33,10 @@ Check [data loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb
 
 When your code requires external library, `%spark.dep` helps load additional libraries from maven repository. `%spark.dep` interpreter leverages Scala environment. You can write scala expressions to call dependency load APIs.
 
+Note that `%spark.dep` should be the first interpreter run in the notebook before `%spark`, `%spark.pyspark`, `%spark.sql`. Otherwise, `%spark.dep` will print error message and you need to shutdown and start the container for the notebook again.
+
+Check [Dependency loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb24vZjBmYWIwNGMzZTcxNDMwN2FjYzIxM2JkYmU3ZWIyZWEvbm90ZS5qc29u) notebook.
+
 Usages
 
 ```scala
@@ -68,7 +72,3 @@ z.load("groupId:artifactId:version").exclude("groupId:*")
 // local() skips adding artifact to spark clusters (skipping sc.addJar())
 z.load("groupId:artifactId:version").local()
 ```
-
-Note that `%spark.dep` should be the first interpreter run in the notebook before `%spark`, `%spark.pyspark`, `%spark.sql`. Otherwise, `%spark.dep` will print error message and you need to shutdown and start the container for the notebook again.
-
-Check [Dependency loading example](https://www.zepl.com/viewer/notebooks/bm90ZTovL21vb24vZjBmYWIwNGMzZTcxNDMwN2FjYzIxM2JkYmU3ZWIyZWEvbm90ZS5qc29u) notebook.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,13 +15,17 @@ pages:
 # - Key Concepts: overview.md
 - User Guide:
     - User Guide: guide/user_guide.md
-    - Sharing Notebooks: guide/sharing_notebooks.md
-    - External Notebooks:
-      - Apache Zeppelin: guide/zeppelin_integration.md
-      - Github: guide/github_integration.md
-      - Amazon S3: guide/s3_integration.md
-    - Import Notebook: guide/import_notebook.md
-    - Explore Public Notebooks: guide/exploring_notebooks.md
+    - Notebook:
+      - Sharing Notebooks: guide/sharing_notebooks.md
+      - External Notebooks:
+        - Apache Zeppelin: guide/zeppelin_integration.md
+        - Github: guide/github_integration.md
+        - Amazon S3: guide/s3_integration.md
+      - Import Notebook: guide/import_notebook.md
+      - Explore Public Notebooks: guide/exploring_notebooks.md
+    - Interpreter:
+      - Apache Spark: guide/interpreter/spark.md
+
 # - Release Notes: release_note.md
 - Support: support.md
 


### PR DESCRIPTION
This PR addes "Apache Spark" under User guide with following content

 - Load data from AWS S3 
 - Load dependencies

This partially addresses [Usecase scenario](https://www.zepl.com/spaces/SSpSddKfs/1d3c09e92ee240e1a8e0055e3b9b5314) #3.5 and #3.6.

To categorize new "Apache Spark" page and all existing pages correctly, I created parent menu "Notebook" and "Interpreter". And put "Apache Spark" under "interpreter" and all existing pages under "Notebook"