### PR TITLE
Make landing page more intuitive, efficient, useful.

### DIFF
--- a/custom_theme/base.html
+++ b/custom_theme/base.html
@@ -62,12 +62,12 @@
 <body{% if current_page and current_page.is_homepage %} class="homepage" {% endif %}>
     {% include "header-bar.html" %}
     <div class="container">
-        {% if '/guide' in page.canonical_url %}
+        {% if '/guide' in page.canonical_url or page.canonical_url == site_url %}
             <div class="toc-menu hidden-xs">{% include "guide-nav.html" %}</div>
             <div class="visible-xs">{% include "search-form.html" %}</div>
         {% endif %}
         {% block content %}
-            {% if '/guide' in page.canonical_url %}
+            {% if '/guide' in page.canonical_url or page.canonical_url == site_url %}
                 <!-- Hack to get side menu only to appear if it's a content menu-->
                 <div class="guide-content hidden-xs">{% include "content.html" %}</div>
                 <div class="visible-xs">{% include "content.html" %}</div>

--- a/custom_theme/content.html
+++ b/custom_theme/content.html
@@ -1,1 +1,4 @@
+{% if page.canonical_url == site_url %}
+  {% include "index.html" %}
+{% endif %}
 {{ content }}

--- a/custom_theme/css/base.css
+++ b/custom_theme/css/base.css
@@ -237,12 +237,28 @@ a.toclink {
     margin: 10px;
 }
 
-input[type=text] {
-        width: 100%;
-        color: #9b9b9b;
-        border: 1px solid #f5f5f5;
-        background-color: #ffffff;
-        border-radius: 5px;
-        padding-left: 10px;
-    }
+#index-search-form {
+    text-align: center;
+    margin-top: 100px;
+}
+#index-search-form input {
+    max-width: 600px;
+    height: 50px;
+    border-color: #9a94ce;
+    font-size: 18px;
+    margin-top: 30px;
+    margin-bottom: 80px;
+}
 
+input[type=text] {
+    width: 100%;
+    color: #555555;
+    border: 1px solid #f5f5f5;
+    background-color: #ffffff;
+    border-radius: 5px;
+    padding-left: 10px;
+}
+
+input[type=text]::placeholder {
+    color: #BBBBBB;
+}

--- a/custom_theme/guide-nav.html
+++ b/custom_theme/guide-nav.html
@@ -1,5 +1,5 @@
 <div class="bs-sidebar">
-	{% include "search-form.html" %}
+    {% include "search-form.html" %}
     {% for nav_item in nav %}
         {% if nav_item.children %}
             {% for guide_item in nav_item.children %}
@@ -7,6 +7,4 @@
             {% endfor %}
         {% endif %}
     {% endfor %}
-
-    </ul>
 </div>

--- a/custom_theme/header-bar.html
+++ b/custom_theme/header-bar.html
@@ -8,13 +8,10 @@
     <div>
       <ul class="nav navbar-nav">
         <li>
-          <a href="{{base_url}}/">Introduction</a>
+          <a href="{{base_url}}/" class="{% if site_url == page.canonical_url %}current{% endif %}">User Guide</a>
         </li>
         <li>
           <a href="{{base_url}}/faq/" class="{% if '/faq' in page.canonical_url %}current{% endif %}">FAQ</a>
-        </li>
-        <li>
-          <a href="{{base_url}}/guide/user_guide/" class="{% if '/guide' in page.canonical_url %}current{% endif %}">User Guide</a>
         </li>
         <!--li>
           <a href="{{base_url}}/release_note/" class="{% if '/release_note' in page.canonical_url %}current{% endif %}">Releases</a>
@@ -40,16 +37,10 @@
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         <li>
-          <a href="{{base_url}}/">Introduction</a>
+          <a href="{{base_url}}/" class="{% if site_url == page.canonical_url %}current{% endif %}">User Guide</a>
         </li>
         <li>
           <a href="{{base_url}}/faq/" class="{% if '/faq' in page.canonical_url %}current{% endif %}">FAQ</a>
-        </li>
-        <li>
-          <a href="{{base_url}}/guide/user_guide/" class="{% if '/guide' in page.canonical_url %}current{% endif %}">User Guide</a>
-        </li>
-        <li>
-          <a href="{{base_url}}/release_note/" class="{% if '/release_note' in page.canonical_url %}current{% endif %}">Releases</a>
         </li>
         <li>
           <a href="{{base_url}}/support/" class="{% if '/support' in page.canonical_url %}current{% endif %}">Support</a>

--- a/custom_theme/index.html
+++ b/custom_theme/index.html
@@ -1,5 +1,5 @@
 <div id="index-search-form">
-  <h1> How we can help? </h1>
+  <h1> How can we help? </h1>
   <form class="wy-form" action="../../search.html" method="get">
     <input type="text" name="q" placeholder="Search docs">
   </form>

--- a/custom_theme/index.html
+++ b/custom_theme/index.html
@@ -1,0 +1,8 @@
+<div id="index-search-form">
+  <h1> How we can help? </h1>
+  <form class="wy-form" action="../../search.html" method="get">
+    <input type="text" name="q" placeholder="Search docs">
+  </form>
+</div>
+<hr />
+<br />

--- a/custom_theme/nav.html
+++ b/custom_theme/nav.html
@@ -23,16 +23,9 @@
                 <!-- Main navigation -->
                 <ul class="nav navbar-nav">
                 {% for nav_item in nav %}
-                    <!-- This is a hack because MKdocs doesn't allow parent index page -->
-                    {% if nav_item.title == "User Guide" %}
-                         <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="/guide">{{ nav_item.title }}</a>
-                        </li>
-                    {% else %}
-                        <li {% if nav_item.active %}class="active"{% endif %}>
-                            <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-                        </li>
-                    {% endif %}
+                    <li {% if nav_item.active %}class="active"{% endif %}>
+                        <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+                    </li>
                 {% endfor %}
                 </ul>
             {% endif %}

--- a/docs/guide/user_guide.md
+++ b/docs/guide/user_guide.md
@@ -1,5 +1,0 @@
-<h1>User Guide</h1>
-
-From this page, you can discover how to use ZEPL to share, collaborate and create your own Notebooks for data science, business intelligence and analytics.
-
-<img src="../../img/landing_page.png" class="image-box big-img"/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,17 +8,17 @@
   </div>
   <div class="col-md-6">
 ### Import existing notebooks
-  - External Notebooks:
+  - External notebooks:
     - [Apache Zeppelin](guide/zeppelin_integration.md)
     - [Github](guide/github_integration.md)
     - [Amazon S3](guide/s3_integration.md)
-  - [Import a Notebook file](guide/import_notebook.md)
+  - [Import a notebook file](guide/import_notebook.md)
 
 ### Share notebooks with your team
-  - [Sharing Notebooks](guide/sharing_notebooks.md)
+  - [Sharing notebooks](guide/sharing_notebooks.md)
 
 ### Publish your notebooks
   - [Publish a notebook](guide/sharing_notebooks/#publishing-notebooks-to-web)
-  - [Explore Public Notebooks](guide/exploring_notebooks.md)
+  - [Explore public notebooks](guide/exploring_notebooks.md)
   </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,13 @@
-# Welcome to Zepl
+### Import existing notebooks
+  - External Notebooks:
+      - [Apache Zeppelin](guide/zeppelin_integration.md)
+      - [Github](guide/github_integration.md)
+      - [Amazon S3](guide/s3_integration.md)
+  - [Import a Notebook file](guide/import_notebook.md)
 
-<span class="middle-font">All-in-one platform, build and share it to the world.</span><br/>
-<span class="middle-font">You’ll never send a graph in PDF or Powerpoint again.</span><br/>
-[ZEPL](https://www.zepl.com/) is where data professionals meet to build amazing graphical reports and collaborate on analytic workflows online.
+### Share notebooks with your team
+  - [Sharing Notebooks](guide/sharing_notebooks.md)
 
-<center><img src="../img/zepl_concept.png" height="80%" width="80%"></center>
-
-<img src="img/instant_feedback.png" class="concept-img"><span class="image-font"> Modular notebooks</span>
-
-Powered by Apache Zeppelin, you can make beautiful data-driven, interactive and collaborative notebooks with SQL, Python and more.
-
-<img src="img/interactive_reports.png" class="concept-img"><span class="image-font"> Quick data visualization</span>
-
-Connect direct to your data or backend system, and visualize using the built-in charts and pivot functions.
-
-<img src="img/keep_uptodate.png" class="concept-img"><span class="image-font"> Collective work</span>
-
-Share your notebook with anyone, anywhere. Instantly communicate and show your changes on the fly. Simplify the feedback process allowing teammates to comment directly on your work.
-
-<br/>
-
-## Who uses ZEPL?
-
-<img src="img/who_uses_big.png" class="who-uses-zepl-big" />
-<img src="img/who_uses_small.png" class="who-uses-zepl-small" />
-
-<br/>
-
-## Show your notebooks on ZEPL
-
-Visualize your public notebooks hosted anywhere and share the best of your work in [ZEPL Explore](https://www.zepl.com/explore) page.
-See [Explore Public Notebooks](exploring_notebooks.md) section for more detailed information.
+### Publish your notebooks
+  - [Publish a notebook](/guide/sharing_notebooks/#publishing-notebooks-to-web)
+  - [Explore Public Notebooks](guide/exploring_notebooks.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,24 @@
+<div markdown="1" class="row">
+  <div class="col-md-6">
+### Load your data
+  - [Load data from S3 using Apache Spark](guide/interpreter/spark/#load-data-from-aws-s3)
+
+### Load additional libraries
+  - [Load dependency libraries from maven repository into Apache Spark](guide/interpreter/spark/#load-dependencies)
+  </div>
+  <div class="col-md-6">
 ### Import existing notebooks
   - External Notebooks:
-      - [Apache Zeppelin](guide/zeppelin_integration.md)
-      - [Github](guide/github_integration.md)
-      - [Amazon S3](guide/s3_integration.md)
+    - [Apache Zeppelin](guide/zeppelin_integration.md)
+    - [Github](guide/github_integration.md)
+    - [Amazon S3](guide/s3_integration.md)
   - [Import a Notebook file](guide/import_notebook.md)
 
 ### Share notebooks with your team
   - [Sharing Notebooks](guide/sharing_notebooks.md)
 
 ### Publish your notebooks
-  - [Publish a notebook](/guide/sharing_notebooks/#publishing-notebooks-to-web)
+  - [Publish a notebook](guide/sharing_notebooks/#publishing-notebooks-to-web)
   - [Explore Public Notebooks](guide/exploring_notebooks.md)
+  </div>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,22 +11,20 @@ site_favicon: favicon.ico
 # Included pages list
 pages:
 - Welcome: index.md
-- FAQ: faq.md
 # - Key Concepts: overview.md
 - User Guide:
-    - User Guide: guide/user_guide.md
-    - Notebook:
-      - Sharing Notebooks: guide/sharing_notebooks.md
-      - External Notebooks:
-        - Apache Zeppelin: guide/zeppelin_integration.md
-        - Github: guide/github_integration.md
-        - Amazon S3: guide/s3_integration.md
-      - Import Notebook: guide/import_notebook.md
-      - Explore Public Notebooks: guide/exploring_notebooks.md
-    - Interpreter:
-      - Apache Spark: guide/interpreter/spark.md
-
+  - Notebook:
+    - Sharing Notebooks: guide/sharing_notebooks.md
+    - External Notebooks:
+      - Apache Zeppelin: guide/zeppelin_integration.md
+      - Github: guide/github_integration.md
+      - Amazon S3: guide/s3_integration.md
+    - Import Notebook: guide/import_notebook.md
+    - Explore Public Notebooks: guide/exploring_notebooks.md
+  - Interpreter:
+    - Apache Spark: guide/interpreter/spark.md
 # - Release Notes: release_note.md
+- FAQ: faq.md
 - Support: support.md
 
 # Theme & Javascript & CSS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,3 +41,4 @@ google_analytics: ['UA-38575365-18', 'docs.zepl.com']
 markdown_extensions:
     - toc:
         anchorlink: True
+    - markdown.extensions.extra


### PR DESCRIPTION
Following is [user behavior on docs.zepl.com in during September](https://analytics.google.com/analytics/web/#report/content-engagement-flow/a38575365w143724583p148362231/%3F_u.date00%3D20170901%26_u.date01%3D20170930/)
![image](https://user-images.githubusercontent.com/1540981/31563989-2740b54c-b016-11e7-8b1d-4f7915301e80.png)

As you see, 1/3 of traffic drop off from landing page.  And https://docs.zepl.com doing duplicate work that https://www.zepl.com landing page does.

And landing page does not provides any information what kind of contents does docs.zepl.com has.
So, 1/3 of traffic is just go away even before know what contents are available.

If we take a look other docs site like https://doc.periscopedata.com/, https://docs.databricks.com/, https://www.cloudera.com/documentation.html  we'll notice that they don't have duplicated information on what their main website does have. Instead they provide informations what kind of document do they have and how to quickly navigate to them.

What this PR improves

 - removes contents that www.zepl.com covers. 
 - expose sitemap (left navbar) on landing page, so user can naturally see the list of contents.
 - provides search input window in more reachable way
 - provides behavior / purpose based document quick link

So, landing page before

![image](https://user-images.githubusercontent.com/1540981/31564624-76d548e6-b018-11e7-9b7d-0dd24a00474a.png)

After
![image](https://user-images.githubusercontent.com/1540981/31579725-2fdcbc7e-b0f1-11e7-88de-034431659c68.png)
