### PR TITLE
Add basic doc for SQL analyist

### DIFF
--- a/custom_theme/css/base.css
+++ b/custom_theme/css/base.css
@@ -222,6 +222,7 @@ li > a.current {
 
 .guide-content {
     margin-left: 280px;
+    min-height: 700px;
 }
 
 a.toclink {

--- a/docs/guide/interpreter/jdbc.md
+++ b/docs/guide/interpreter/jdbc.md
@@ -1,0 +1,35 @@
+<h1> JDBC Interpreter </h1>
+
+ZEPL supports JDBC interpreter with drivers for popular databases. To connect your database, it's important to check
+
+  - Database is currently up and running
+  - Database is accessible from public internet
+  - You have proper credentials to access database
+
+## Create new JDBC Interpreter
+
+First, you'll need to create an intepreter to provide database connection information.
+
+1. Click **Create interpreter** button from [Interpreter](https://www.zepl.com/settings/interpreters) page.
+2. Select **jdbc** in Interprer group
+3. Type **Interpreter name**. This name will be used in the notebook to call this JDBC interpreter.
+4. Type **JDBC connection URL**, **username** and **password**.
+5. Select **JDBC driver**
+
+You can use **Test connection** button to test connection.
+
+### Use your JDBC Interpreter
+
+Once you have created JDBC interpreter, you can call it in the notebook using `%[Interpreter name]` directive. For example if you have created your JDBC interpreter with name "psql", you can call it `%psql` in the notebook. i.e.
+
+```
+%psql
+SELECT * from my_table
+```
+
+## Secure database connection
+
+### Whitelist IP addresses
+ZEPL connects your database using two IP addresses **52.38.31.66** and **52.32.218.160**. It's always good idea setup firewall and whitelist the IP.
+
+

--- a/docs/guide/interpreter/jdbc.md
+++ b/docs/guide/interpreter/jdbc.md
@@ -1,6 +1,6 @@
 <h1> JDBC Interpreter </h1>
 
-ZEPL supports JDBC interpreter with drivers for popular databases. To connect your database, it's important to check
+ZEPL supports JDBC interpreter with drivers for popular databases. Before connecting to your database, it's important to check the following:
 
   - Database is currently up and running
   - Database is accessible from public internet
@@ -11,16 +11,16 @@ ZEPL supports JDBC interpreter with drivers for popular databases. To connect yo
 First, you'll need to create an intepreter to provide database connection information.
 
 1. Click **Create interpreter** button from [Interpreter](https://www.zepl.com/settings/interpreters) page.
-2. Select **jdbc** in Interprer group
-3. Type **Interpreter name**. This name will be used in the notebook to call this JDBC interpreter.
-4. Type **JDBC connection URL**, **username** and **password**.
-5. Select **JDBC driver**
+2. Select **jdbc** in Interpreter group
+3. Provide an **Interpreter name**. This name will be used in the notebook to call this JDBC interpreter.
+4. Provide a **JDBC connection URL**, **username** and **password**.
+5. Select a **JDBC driver**
 
-You can use **Test connection** button to test connection.
+Use the **Test connection** button to test the connection.
 
 ### Use your JDBC Interpreter
 
-Once you have created JDBC interpreter, you can call it in the notebook using `%[Interpreter name]` directive. For example if you have created your JDBC interpreter with name "psql", you can call it `%psql` in the notebook. i.e.
+Once you have created the JDBC interpreter, you can use it in your notebook by providing the `%[Interpreter name]` directive. For example, if you have created your JDBC interpreter with name "psql", you can use `%psql` in the notebook. i.e.
 
 ```
 %psql
@@ -30,6 +30,5 @@ SELECT * from my_table
 ## Secure database connection
 
 ### Whitelist IP addresses
-ZEPL connects your database using two IP addresses **52.38.31.66** and **52.32.218.160**. It's always good idea setup firewall and whitelist the IP.
-
+ZEPL connects your database using two IP addresses **52.38.31.66** and **52.32.218.160**. It's recommended to setup firewall and whitelist the IP.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@
 
 ### Load additional libraries
   - [Load dependency libraries from maven repository into Apache Spark](guide/interpreter/spark/#load-dependencies)
+### Secure JDBC connection
+  - [Whitelist IP addresses](guide/interpreter/jdbc/#whitelist-ip-addresses)
   </div>
   <div class="col-md-6">
 ### Import existing notebooks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ pages:
     - Explore Public Notebooks: guide/exploring_notebooks.md
   - Interpreter:
     - Apache Spark: guide/interpreter/spark.md
+    - JDBC : guide/interpreter/jdbc.md
 # - Release Notes: release_note.md
 - FAQ: faq.md
 - Support: support.md


### PR DESCRIPTION
Add basic JDBC doc. this branch is based on #18.

JDBC page is located under Interpreter menu and looks like
![image](https://user-images.githubusercontent.com/1540981/31632507-022b3d96-b272-11e7-9db6-a4420eecbcb5.png)

Added "Secure JDBC connection" section
![image](https://user-images.githubusercontent.com/1540981/31632517-0c135564-b272-11e7-9323-37fc4f63754c.png)
