### PR TITLE
fix link in custom image support docs

### DIFF
--- a/docs/guide/enterprise/custom_image_support.md
+++ b/docs/guide/enterprise/custom_image_support.md
@@ -76,7 +76,7 @@ Use "zcr [command] --help" for more information about a command.
 `zcr` requires a definition file which defines custom packages for interpreters such as R libraries and Pip packages.
 With the `zcr create` command, users are able to build / push / register the custom interpreter image.
 
-For the definition file, please refer [the definition section below](./#definition-file-spec).
+For the definition file, please refer [the definition section below](./custom_image_support/#definition-file-spec).
 
 ```bash
 # make sure that you exported `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as env variables.
@@ -277,8 +277,3 @@ import pandas
 !ls -al /usr/zepl/interpreter/lib | grep mysql
 !ls -al /usr/zepl/interpreter/lib | grep athena
 ```
-
-
-
-
-


### PR DESCRIPTION
while going through docs found minor problem in hyperlink

when clicking on below hyperlink
<img width="512" alt="screen shot 2018-12-21 at 12 11 35 pm" src="https://user-images.githubusercontent.com/1642088/50322728-bd507a00-0519-11e9-9f5f-e2592df30ad0.png">


before 
<img width="969" alt="screen shot 2018-12-21 at 12 11 15 pm" src="https://user-images.githubusercontent.com/1642088/50322721-b0338b00-0519-11e9-9a14-68b4f6b67a54.png">

after
<img width="1150" alt="screen shot 2018-12-21 at 12 11 56 pm" src="https://user-images.githubusercontent.com/1642088/50322732-c3465b00-0519-11e9-8f38-3808217ed50f.png">
