### PR TITLE
[ZEPL-5503] Add page.meta.description as meta tag in every page

### DIFF
--- a/custom_theme/base.html
+++ b/custom_theme/base.html
@@ -5,7 +5,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% if config.site_description %}
+    {% if page.meta %}
+    <meta name="description" content="{{ page.meta.description }}">
+    {% else %}
     <meta name="description" content="{{ config.site_description }}">
     {% endif %}
     {% if config.site_author %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,6 @@ markdown_extensions:
     - toc:
         anchorlink: True
     - markdown.extensions.extra
-    - meta
 
 plugins:
     - search


### PR DESCRIPTION
For SEO, we want to have different description for each page.
By adding `description` field in each page, each page will have different `<meta>` tag in document site.

https://www.mkdocs.org/user-guide/custom-themes/#pagemeta

For example if you put
`description: exploreing notebooks!!!!` in the top of docs/guide/exploring_notebooks.md file, you will be able to see meta tag:
<img width="540" alt="Screen Shot 2019-07-15 at 6 30 12 PM" src="https://user-images.githubusercontent.com/8503346/61259351-ab8d2900-a72e-11e9-8975-4d46be7b4d65.png">
